### PR TITLE
Update WG6 kick-off webpage with speaker info

### DIFF
--- a/_pages/WG6/2022-05-kickoff/wg6-kickoff.md
+++ b/_pages/WG6/2022-05-kickoff/wg6-kickoff.md
@@ -7,7 +7,7 @@ permalink: /wg6-kickoff-stockholm/
 ## Overview
 
 - Dates: Fri 20–Sat 21 May 2022
-- Location: Stockholm University, Dept of Mathematics ([website](https://www.su.se/matematiska-institutionen/), [map](https://w3w.co/classic.handbook.proven))
+- Location: Stockholm University, Dept. of Mathematics ([website](https://www.su.se/matematiska-institutionen/), [map](https://w3w.co/classic.handbook.proven))
 
 The workshop will bring together researchers on the topics of [working group 6](/wg6), to share recent results, and co-ordinate future research, including collaboration towards deliverables.
 
@@ -15,14 +15,45 @@ The programme will consist primarily of short talks, with plenty of time for dis
 
 - Organisers: [Anders Mörtberg](https://staff.math.su.se/anders.mortberg/), [Benedikt Ahrens](https://benediktahrens.gitlab.io), [Peter LeFanu Lumsdaine](http://peterlefanulumsdaine.com)
 
-## Registration, talk submission, funding application
+## Speakers
+
+### Invited
+
+- Andrej Bauer: *TBA*
+- Anja Petković Komel: *TBA*
+- András Kovacs: *TBA*
+- Ivan Di Liberti: *TBA*
+- Jonathan Sterling: *Naïve logical relations in synthetic Tait computability*
+- Taichi Uemura: *TBA*
+- Théo Winterhalter: *TBA*
+
+### Contributed
+
+- Steve Awodey: *Kripke-Joyal forcing for Martin-Löf type theory*
+- Henning Basold: *Towards Behavioural Types as Coalgebras*
+- Maximilian Doré: *Automating Kan composition*
+- Jacopo Emmenegger: *B-systems and C-systems are equivalent*
+- Jonas Frey: *Characterizing clan-algebraic categories*
+- Roussanka Loukanova: *Syntax-Semantics of Simply Typed Theory of Acyclic Algorithms*
+- Kenji Maillard: *The Multiverse: *Logical Modularity for Proof Assistants*
+- Iosif Petrakis: *Positive negation in constructive mathematics*
+- Sergei Soloviev: *Consequences of Computational Asymmetry in Verifier-Falsifier Games*
+- Raffael Stenzel: *Higher geometric sheaf theories*
+- Niels Van der Weide: *Semantics for two-dimensional type theory*
+- David Wärn: *Effective quotients in homotopy type theory*
+
+## Schedule
+
+**TBA**
+
+## Registration
 
 Registration is free, but required for planning purposes, by **Friday 13 May**: [registration form](https://forms.gle/zgvMSjBUVD392kPs6).
 
-There is some space remaining for contributed talks. If you would like to talk, please submit a proposal (title and short abstract) along with your registration, by **Monday 11 April**.
+<!-- There is some space remaining for contributed talks. If you would like to talk, please submit a proposal (title and short abstract) along with your registration, by **Monday 11 April**. -->
 
-We have a limited amount of funding available for travel and accommodation.  Priority will be given to speakers, participants from “Inclusiveness Target Countries”, early-career researchers, and women (following the EU COST inclusiveness policy, details [here](https://www.cost.eu/about/cost-strategy/excellence-and-inclusiveness/)).  Funding applications should be submitted with your registration, by **Monday 11 April**, and will be decided later that week.
+<!-- We have a limited amount of funding available for travel and accommodation.  Priority will be given to speakers, participants from “Inclusiveness Target Countries”, early-career researchers, and women (following the EU COST inclusiveness policy, details [here](https://www.cost.eu/about/cost-strategy/excellence-and-inclusiveness/)).  Funding applications should be submitted with your registration, by **Monday 11 April**, and will be decided later that week. -->
 
-## Reimbursement
+## Reimbursement for those that applied for funding
 
 See the [reimbursement rules](../reimbursement-rules).


### PR DESCRIPTION
I added some information about invited and confirmed speakers. I haven't figure out how to build the webpage locally, so I could not test what I did. I hope it all looks fine. @peterlefanulumsdaine  Can you test it?

I'm not sure how to add the abstracts in a nice way, but for now I think this will do and we can get the abstracts up with the schedule.