### PR TITLE
Add reference to another mathematical theory of type theories

### DIFF
--- a/_pages/deliverables/4.md
+++ b/_pages/deliverables/4.md
@@ -11,6 +11,8 @@ Different theories have been developed, some taking a more syntactic approach to
 
 * [A type- and scope-safe universe of syntaxes with binding: their semantics and proofs](https://doi.org/10.1017/S0956796820000076), Guillaume Allais, Robert Atkey, James Chapman, Conor McBride, James McKinna, Journal of Functional Programming, 2021
 
+* [Algebraic models of simple type theories: a polynomial approach](https://doi.org/10.1145/3373718.3394771), Nathanael Arkor, Marcelo Fiore, Logic in Computer Science, 2020
+
 * [An extensible equality checking algorithm for dependent type theories](https://doi.org/10.46298/lmcs-18(1:17)2022), Andrej Bauer, Anja Petkovic Komel, Logical Methods in Computer Science 18(1), 2022.
 
 * [Formal metatheory of second-order abstract syntax](https://dl.acm.org/doi/10.1145/3498715), Marcelo Fiore, Dmitrij Szamozvancev, Principles Of Programming Languages, 2022


### PR DESCRIPTION
This reference provides a category-theoretic approach to simple type theories and their presentations.