### PR TITLE
Added the SWS group

### DIFF
--- a/_pages/groups.md
+++ b/_pages/groups.md
@@ -42,6 +42,7 @@ Groups marked with (EPN) have members participating to EuroProofNet.
 **Estonia**
 
 - [Logic and Semantics group](https://cs.ioc.ee/lsg/), Tallinn University of Technology (EPN)
+- [Laboratory for Software Science](https://sws.cs.ut.ee), University of Tartu (EPN)
 
 **Finland**
 


### PR DESCRIPTION
Added the Laboratory for Software Science  (SWS) group at the University of Tartu to the research groups page