### PR TITLE
WG5: add note for attendees with children

### DIFF
--- a/_pages/WG5/Vienna24/meeting.md
+++ b/_pages/WG5/Vienna24/meeting.md
@@ -46,6 +46,9 @@ Selected participants will have **2 weeks** to accept the invitation sent from e
 If you do not accept the invitation within 2 weeks, you will not be reimbursed.
 Support will be at a flat rate of approximately €160 per day.
 
+TU Wien has facilities for attendees with children, including a dedicated parent-child room.
+Please e-mail the organisers for more details if you would like to make use of them.
+
 ### Location
 
 [Hörsaal Zemanek](https://tuw-maps.tuwien.ac.at/?q=HHEG01)


### PR DESCRIPTION
My colleague at TU Wien reliably informs me there are options for attendees with children. Apologies for my ignorance. Add a (belated) note to the upcoming WG5 meeting page.