### PR TITLE
New publication: Maude2Lean in JLAMP

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -18,6 +18,7 @@ To contribute to the web site, please open an [issue](https://github.com/EuroPro
 - [Formal Specification and Verification of Architecturally-Defined Attestation Mechanisms in Arm CCA and Intel TDX](https://doi.org/10.1109/access.2023.3346501), M. U. Sardar, T. Fossati, S. Frost, S. Xiong, IEEE Access, pp. 361-381, vol 12.
 - [Translating HOL-Light proofs to Coq](https://doi.org/10.29007/6k4x), Frédéric Blanqui, 25th International Conference on Logic for Programming, Artificial Intelligence and Reasoning (LPAR).
 - [Sharing proofs with predicative theories through universe-polymorphic elaboration](https://doi.org/10.46298/lmcs-20(3:23)2024), Thiago Felicissimo and Frédéric Blanqui, Logical Methods in Computer Science, Volume 20, Issue 3. 
+- [Maude2Lean: Theorem proving for Maude specifications using Lean](https://doi.org/10.1016/j.jlamp.2024.101005), Rubén Rubio and Adrián Riesco, [*JLAMP*](https://www.sciencedirect.com/journal/journal-of-logical-and-algebraic-methods-in-programming)
 
 **2023**
 


### PR DESCRIPTION
This commit adds a new entry in the publication list for the article [*Maude2Lean: Theorem proving for Maude specifications using Lean*](https://doi.org/10.1016/j.jlamp.2024.101005) with @ariesco, published in JLAMP. It follows the same format as previous similar entries.

The formal publication year is 2025, but the article has been published online a month ago.