### PR TITLE
Update info on the 2025 Summer School in Bonn and add groups

### DIFF
--- a/_pages/events.md
+++ b/_pages/events.md
@@ -15,7 +15,7 @@ author_profile: true
 
 - 5-6 June 2025: [Workshop on Reasoning with Quantitative Types](https://europroofnet.github.io/WRQT2025/), Porto, Portugal
 - 3-5 June 2025: [WG2 meeting on ATPs for geometry](../wg2-geo25), Krakow, Poland
-- 3-5 June 2025: [School on Natural Language Formalizations](https://naproche.github.io/school/) (SoNaLF), Bonn, Germany
+- 3-5 June 2025: [School on Natural Formal Mathematics](https://naproche.github.io/school/), Bonn, Germany
 - 17-18 April 2025: [WG6 meeting](../wg6-genoa/), co-located with the [2025 Workshop on Homotopy Type Theory / Univalent Foundations](https://hott-uf.github.io/2025/) (HoTT/UF), Genoa, Italy
 - 7-8 April 2025: [WG5 meeting on Theorem Proving with LLMs: SoA and Future Perspectives](../wg5-edinburgh25), Edinburgh, UK
 - 11-13 February 2025: [WG1 meeting](../Nogent25/), Nogent-sur-Seine, France

--- a/_pages/groups.md
+++ b/_pages/groups.md
@@ -62,6 +62,12 @@ Groups marked with (EPN) have members participating to EuroProofNet.
 
 **Germany**
 
+- [HCM Interdisciplinary Research Unit 2: Formalized mathematics and computer-assisted proofs](https://florisvandoorn.com/formalized-mathematics), Bonn
+- [Mathematical Logic Group](https://www.math.uni-bonn.de/ag/logik/), Bonn (EPN)
+- [Chair for Logic and Verification](https://www21.in.tum.de/), Munich (EPN)
+- [KWARC](https://kwarc.info/), Erlangen (EPN)
+- [Research Group Formal Methods and theoretical Computer Science](https://www.uni-koblenz.de/en/computer-science/ics/sofronie-stokkermans), Koblenz
+
 **Greece**
 
 **Hungary**
@@ -161,6 +167,7 @@ Groups marked with (EPN) have members participating to EuroProofNet.
 - [Logic Group](https://eps.leeds.ac.uk/maths-pure-mathematics/doc/logic), University of Leeds (EPN)
 - [Mathematically Structured Programming Group](http://msp.cis.strath.ac.uk/), University of Strathclyde (EPN)
 - [Programming, Logic, and Semantics Group](https://www.cl.cam.ac.uk/research/pls/index.html), University of Cambridge (EPN)
+- [Human-Oriented Automatic Theorem Proving Project](https://wtgowers.github.io/human-style-atp/), Cambridge
 - [Software Systems group](https://www.kcl.ac.uk/research/ssy), King's College London (EPN)
 - [Theory of Computation](https://www.birmingham.ac.uk/research/activity/computer-science/theory-of-computation/index.aspx), University of Birmingham (EPN)
 - [Department of Computer Science](https://www.royalholloway.ac.uk/research-and-teaching/departments-and-schools/computer-science/), Royal Holloway, University of London

--- a/_pages/schools.md
+++ b/_pages/schools.md
@@ -7,6 +7,8 @@ author_profile: true
 
 To contribute to the web site, please open an [issue](https://github.com/EuroProofNet/europroofnet.github.io/issues), create a [pull request](https://github.com/EuroProofNet/europroofnet.github.io) or send a mail to the [science communication coordinators](../contact).
 
+- 3-5 June 2025: [School on Natural Formal Mathematics](https://naproche.github.io/school/), Bonn, Germany
+
 - 15-21 September 2024: school on [Proof & Computation](http://www.mathematik.uni-muenchen.de/~schwicht/pc24.php), Fischbachau, Germany
 
 - 25 August - 1st September 2024: [14th International School on Rewriting](http://cl-informatik.uibk.ac.at/isr24/) (ISR'24), Obergurgl, Austria

--- a/_pages/wg5.md
+++ b/_pages/wg5.md
@@ -17,9 +17,9 @@ computer-assisted reasoning can be extended to proofs that are represented in
 -  Detailed technical report on the evaluation of techniques for learning proof search
 guidance and premise selection in automated theorem provers.
     - [Learning Guided Automated Reasoning: A Brief Survey](https://link.springer.com/chapter/10.1007/978-3-031-61716-4_4) Lasse Blaauwbroek, David M. Cerna, Thibault Gauthier, Jan Jakubův, Cezary Kaliszyk, Martin Suda, Josef Urban, Logics and Type Systems in Theory and Practice 2024.
-- White paper on including restricted natural language proof formats to existing proof libraries. 
+- White paper on including restricted natural language proof formats to existing proof libraries.
 ### Activities
-- 3-5 June 2025: [School on Natural Language Formalizations](https://naproche.github.io/school/) (SoNaLF), Bonn, Germany
+- 3-5 June 2025: [School on Natural Formal Mathematics](https://naproche.github.io/school/), Bonn, Germany
 - 7-8 April 2025: [Theorem Proving with LLMs: SoA and Future Perspectives](/wg5-edinburgh25), Edinburgh, Scotland, UK
 - 24-27 June 2024: [EuroProofNet Summer School on AI for Reasoning and Processing of Mathematics](/Kutaisi24), Kutaisi, Georgia
 - 25-26 March 2024: [Workshop on Alignment of Proof Systems and Machine Learning](/wg5-vienna24), Vienna, Austria


### PR DESCRIPTION
I've updated the name of the Summer School in Bonn and added it to the schools page (in addition to the already existing links on the events page).

I've also added some groups in Germany and the UK.